### PR TITLE
Gitops 1.3.1 not in stable channel anymore

### DIFF
--- a/seeds/common/policy/openshift-gitops.yaml
+++ b/seeds/common/policy/openshift-gitops.yaml
@@ -36,7 +36,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.3
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators


### PR DESCRIPTION
Changed the channel to gitops-1.3 but the fix could also be to not specify the starting CSV. In general I prefer having the version explicitly (like in maven) to avoid future breaking changes. 